### PR TITLE
prevent default propagation of keydown event

### DIFF
--- a/script/input.js
+++ b/script/input.js
@@ -9,18 +9,22 @@ let lastInputDirection = { x: 0, y: 0 };
 window.addEventListener('keydown', e => {
     switch (e.key) {
         case 'ArrowUp':
+            e.preventDefault();
             if (lastInputDirection.y !== 0) break;
             inputDirection = { x: 0, y: -1 };
             break;
         case 'ArrowDown':
+            e.preventDefault();
             if (lastInputDirection.y !== 0) break;
             inputDirection = { x: 0, y: 1 };
             break;
         case 'ArrowLeft':
+            e.preventDefault();
             if (lastInputDirection.x !== 0) break;
             inputDirection = { x: -1, y: 0 };
             break;
         case 'ArrowRight':
+            e.preventDefault();
             if (lastInputDirection.x !== 0) break;
             inputDirection = { x: 1, y: 0 };
             break;


### PR DESCRIPTION
When handling the keydown event in input.js, you should prevent the default propagation of the event to other observers. 

This can be achieved by calling preventDefault() on the event object. 

With this change, the focus is no longer transferred between the radio buttons when using the arrow keys if one radio button is focussed.

